### PR TITLE
Create `out` directory before saving plots there

### DIFF
--- a/04_output.R
+++ b/04_output.R
@@ -27,6 +27,8 @@ library(readr)
 if (!exists("ozone_caaqs_results")) load("tmp/analysed.RData")
 if (!exists("max_year")) load("tmp/ozone_clean.RData")
 
+# Create output directory:
+dir.create("out", showWarnings = FALSE)
 
 ## WEB & PDF OUTPUTS ##
 


### PR DESCRIPTION
The `04_output.R` script currently tries to save some plots in the `out/` directory before this directory exists, causing errors at this line:

https://github.com/bcgov/ozone-caaqs-indicator/blob/0df90478270eff59d4501569b29c057fe0d13994/04_output.R#L45-L46

This PR ensures the directory is created before any plots are saved to it. 